### PR TITLE
Fix safe 14 canary

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ const NEXT_CANARY_PATCHES = {
 };
 
 const NEXT_14_SAFE_VERSION = '14.2.29';
-const NEXT_14_SAFE_CANARY = '14.3.0-canary.76';
+const NEXT_14_SAFE_CANARY = '14.3.0-canary.77';
 
 const REACT_RSC_PATCHES = {
   '19.0.0': '19.0.1',


### PR DESCRIPTION
.76 is vulnerable. .77 is safe: https://nextjs.org/blog/CVE-2025-66478#affected-nextjs-versions