### PR TITLE
handle catalog version of next.js false positives

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,6 @@ const NEXT_CANARY_PATCHES = {
   16: '16.1.0-canary.12',
 };
 
-const NEXT_14_SAFE_VERSION = '14.2.29';
 const NEXT_14_SAFE_CANARY = '14.3.0-canary.76';
 
 const REACT_RSC_PATCHES = {
@@ -269,19 +268,6 @@ function getReactRscPatchedVersion(version) {
   return REACT_RSC_PATCHES[cleaned] || null;
 }
 
-function detectPackageManager(cwd) {
-  if (fs.existsSync(path.join(cwd, 'bun.lockb')) || fs.existsSync(path.join(cwd, 'bun.lock'))) {
-    return 'bun';
-  }
-  if (fs.existsSync(path.join(cwd, 'pnpm-lock.yaml'))) {
-    return 'pnpm';
-  }
-  if (fs.existsSync(path.join(cwd, 'yarn.lock'))) {
-    return 'yarn';
-  }
-  return 'npm';
-}
-
 function getInstalledVersionFromNodeModules(pkgDir, packageName) {
   const nodeModulesPath = path.join(pkgDir, 'node_modules', packageName, 'package.json');
   try {
@@ -292,37 +278,97 @@ function getInstalledVersionFromNodeModules(pkgDir, packageName) {
   }
 }
 
+function findLockFileRoot(startDir) {
+  let dir = startDir;
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, 'pnpm-lock.yaml')) ||
+        fs.existsSync(path.join(dir, 'package-lock.json')) ||
+        fs.existsSync(path.join(dir, 'yarn.lock')) ||
+        fs.existsSync(path.join(dir, 'bun.lockb')) ||
+        fs.existsSync(path.join(dir, 'bun.lock'))) {
+      return dir;
+    }
+    dir = path.dirname(dir);
+  }
+  return startDir;
+}
+
 function getInstalledVersionFromPackageManager(pkgDir, packageName) {
+  // Find the root where lock file lives (for monorepos)
+  const rootDir = findLockFileRoot(pkgDir);
   const packageManager = detectPackageManager(pkgDir);
   
   try {
     if (packageManager === 'pnpm') {
-      const result = spawnSync('pnpm', ['list', packageName, '--json', '--depth=0'], {
-        cwd: pkgDir,
+      // Use pnpm why for reliable version resolution (handles catalogs, overrides, etc.)
+      const result = spawnSync('pnpm', ['why', packageName, '--json'], {
+        cwd: rootDir,
         encoding: 'utf8',
         shell: process.platform === 'win32',
       });
       if (result.status === 0 && result.stdout) {
         const data = JSON.parse(result.stdout);
-        // pnpm list --json returns an array of projects
-        for (const project of data) {
-          const dep = project.dependencies?.[packageName] || project.devDependencies?.[packageName];
-          if (dep?.version) return dep.version;
+        // pnpm why --json returns object with "packageName@version" as keys
+        const keys = Object.keys(data);
+        for (const key of keys) {
+          if (key.startsWith(packageName + '@')) {
+            return key.slice(packageName.length + 1);
+          }
         }
       }
     } else if (packageManager === 'npm') {
       const result = spawnSync('npm', ['list', packageName, '--json', '--depth=0'], {
-        cwd: pkgDir,
+        cwd: rootDir,
         encoding: 'utf8',
         shell: process.platform === 'win32',
       });
-      if (result.stdout) {
+      if (result.status === 0 && result.stdout) {
         const data = JSON.parse(result.stdout);
         const dep = data.dependencies?.[packageName];
         if (dep?.version) return dep.version;
       }
+    } else if (packageManager === 'yarn') {
+      // yarn why outputs package info with version
+      const result = spawnSync('yarn', ['why', packageName, '--json'], {
+        cwd: rootDir,
+        encoding: 'utf8',
+        shell: process.platform === 'win32',
+      });
+      if (result.status === 0 && result.stdout) {
+        // yarn why --json outputs newline-delimited JSON
+        const lines = result.stdout.trim().split('\n');
+        for (const line of lines) {
+          try {
+            const entry = JSON.parse(line);
+            // yarn classic: { "type": "info", "data": "... version \"x.x.x\"" }
+            // yarn berry: { "value": "packageName@npm:x.x.x" }
+            if (entry.value && entry.value.includes('@')) {
+              const match = entry.value.match(/@(?:npm:)?(\d+\.\d+\.\d+[^\s]*)/);
+              if (match) return match[1];
+            }
+            if (entry.data && typeof entry.data === 'string') {
+              const match = entry.data.match(/version "([^"]+)"/);
+              if (match) return match[1];
+            }
+          } catch (e) {
+            // Skip malformed lines
+          }
+        }
+      }
+    } else if (packageManager === 'bun') {
+      // bun pm ls shows installed packages
+      const result = spawnSync('bun', ['pm', 'ls'], {
+        cwd: rootDir,
+        encoding: 'utf8',
+        shell: process.platform === 'win32',
+      });
+      if (result.status === 0 && result.stdout) {
+        // Parse output like "├── next@15.1.9"
+        const regex = new RegExp(`[├└]── ${packageName}@([\\d.]+[^\\s]*)`, 'm');
+        const match = result.stdout.match(regex);
+        if (match) return match[1];
+      }
     }
-    // yarn and bun: just use node_modules fallback (more reliable across versions)
   } catch (e) {
     // Fall through to node_modules check
   }
@@ -404,7 +450,7 @@ function analyzePackageJson(pkgPath) {
         inDeps: !!pkg.dependencies?.next,
         inDevDeps: !!pkg.devDependencies?.next,
       });
-    } else if ((isCatalogReference(allDeps.next) || isUnparseableVersionSpec(allDeps.next)) && !resolvedVersion) {
+    } else if ((isCatalogReference(allDeps.next) || isUnparseableVersionSpec(allDeps.next) || !parseVersion(allDeps.next)) && !resolvedVersion) {
       vulnerabilities.push({
         package: 'next',
         current: allDeps.next,
@@ -422,7 +468,7 @@ function analyzePackageJson(pkgPath) {
       let resolvedVersion = null;
       let displayVersion = version;
       
-      if (isCatalogReference(version) || isUnparseableVersionSpec(version)) {
+      if (isCatalogReference(version) || isUnparseableVersionSpec(version) || !parseVersion(version)) {
         resolvedVersion = getInstalledVersion(pkgDir, rscPkg);
         if (resolvedVersion) {
           displayVersion = `${version} (resolved: ${resolvedVersion})`;
@@ -438,7 +484,7 @@ function analyzePackageJson(pkgPath) {
           inDeps: !!pkg.dependencies?.[rscPkg],
           inDevDeps: !!pkg.devDependencies?.[rscPkg],
         });
-      } else if ((isCatalogReference(allDeps[rscPkg]) || isUnparseableVersionSpec(allDeps[rscPkg])) && !resolvedVersion) {
+      } else if ((isCatalogReference(allDeps[rscPkg]) || isUnparseableVersionSpec(allDeps[rscPkg]) || !parseVersion(allDeps[rscPkg])) && !resolvedVersion) {
         vulnerabilities.push({
           package: rscPkg,
           current: allDeps[rscPkg],
@@ -526,15 +572,6 @@ function findMonorepoRoot(startDir) {
   }
   
   return null;
-}
-
-function getInstallCommand(packageManager) {
-  switch (packageManager) {
-    case 'bun': return 'bun install';
-    case 'pnpm': return 'pnpm install';
-    case 'yarn': return 'yarn install';
-    default: return 'npm install';
-  }
 }
 
 function applyFixes(pkgPath, vulnerabilities) {


### PR DESCRIPTION
handle false positives from next.js catalog versions

> I think it's more robust to use the package managers directly to find the installed version e.g. pnpm why next --json


wip