### PR TITLE
feat: Add CVE-2025-55182 support for React core packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,46 @@ Deterministic version bumps per the official advisories.
 | 16.x canaries | 16.1.0-canary.12 |
 | 14.3.0-canary.77+ | Downgrade to 14.3.0-canary.76 or upgrade to 15.0.5 |
 
-### React Packages (CVE-2025-55182)
+### React Server Components (CVE-2025-55182)
 
 | Current Version | Patched Version |
 |-----------------|-----------------|
-| 19.0.0 | 19.0.1 |
-| 19.1.0, 19.1.1 | 19.1.2 |
-| 19.2.0 | 19.2.1 |
+| 19.0.0 | 19.0.2 |
+| 19.1.0, 19.1.1 | 19.1.3 |
+| 19.2.0 | 19.2.2 |
 
 *Applies to: `react`, `react-dom`, `react-server-dom-webpack`, `react-server-dom-parcel`, `react-server-dom-turbopack`*
+
+### React Server Components (CVE-2025-55184)
+
+| Current Version | Patched Version |
+|-----------------|-----------------|
+| 19.0.0, 19.0.1 | 19.0.2 |
+| 19.1.0, 19.1.1, 19.1.2 | 19.1.3 |
+| 19.2.0, 19.2.1 | 19.2.2 |
+
+*Applies to: `react-server-dom-webpack`, `react-server-dom-parcel`, `react-server-dom-turbopack`*
+
+### React Server Components (CVE-2025-55183)
+
+| Current Version | Patched Version |
+|-----------------|-----------------|
+| 19.0.0, 19.0.1 | 19.0.2 |
+| 19.1.0, 19.1.1, 19.1.2 | 19.1.3 |
+| 19.2.0, 19.2.1 | 19.2.2 |
+
+*Applies to: `react-server-dom-webpack`, `react-server-dom-parcel`, `react-server-dom-turbopack`*
+
+### React Server Components (CVE-2025-67779)
+
+| Current Version | Patched Version |
+|-----------------|-----------------|
+| 19.0.2 | 19.0.3 |
+| 19.1.3 | 19.1.4 |
+| 19.2.2 | 19.2.3 |
+
+*Applies to: `react-server-dom-webpack`, `react-server-dom-parcel`, `react-server-dom-turbopack`*
+*Note: Incomplete fix follow-up for CVE-2025-55184*
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Deterministic version bumps per the official advisories.
 | 16.x canaries | 16.1.0-canary.12 |
 | 14.3.0-canary.77+ | Downgrade to 14.3.0-canary.76 or upgrade to 15.0.5 |
 
-### React Core Packages
+### React Packages (CVE-2025-55182)
 
 | Current Version | Patched Version |
 |-----------------|-----------------|
@@ -46,15 +46,7 @@ Deterministic version bumps per the official advisories.
 | 19.1.0, 19.1.1 | 19.1.2 |
 | 19.2.0 | 19.2.1 |
 
-*Applies to: `react`, `react-dom`*
-
-### React RSC Packages
-
-| Current Version | Patched Version |
-|-----------------|-----------------|
-| 19.0.0 | 19.0.1 |
-| 19.1.0, 19.1.1 | 19.1.2 |
-| 19.2.0 | 19.2.1 |
+*Applies to: `react`, `react-dom`, `react-server-dom-webpack`, `react-server-dom-parcel`, `react-server-dom-turbopack`*
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![fix-react2shell-next](https://raw.githubusercontent.com/vercel-labs/fix-react2shell-next/main/cli.gif)
 
-One command to fix **[CVE-2025-66478](https://nextjs.org/blog/CVE-2025-66478)** (React 2 Shell RCE) in your Next.js / React RSC app.
+One command to fix multiple React/Next.js security vulnerabilities in your Next.js / React RSC app.
 
 ```bash
 npx fix-react2shell-next
@@ -37,6 +37,16 @@ Deterministic version bumps per the official advisories.
 | 15.x canaries | 15.6.0-canary.58 |
 | 16.x canaries | 16.1.0-canary.12 |
 | 14.3.0-canary.77+ | Downgrade to 14.3.0-canary.76 or upgrade to 15.0.5 |
+
+### React Core Packages
+
+| Current Version | Patched Version |
+|-----------------|-----------------|
+| 19.0.0 | 19.0.1 |
+| 19.1.0, 19.1.1 | 19.1.2 |
+| 19.2.0 | 19.2.1 |
+
+*Applies to: `react`, `react-dom`*
 
 ### React RSC Packages
 

--- a/lib/vulnerabilities/cve-2025-55182.js
+++ b/lib/vulnerabilities/cve-2025-55182.js
@@ -1,0 +1,59 @@
+/**
+ * CVE-2025-55182: React Server Components Vulnerability
+ * @see https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components
+ *
+ * Affected packages:
+ * - react: 19.0.0, 19.1.0, 19.1.1, 19.2.0
+ * - react-dom: 19.0.0, 19.1.0, 19.1.1, 19.2.0
+ */
+
+const { cleanVersion } = require('../utils/version');
+
+// Vulnerable versions and their patches for React core packages
+const REACT_PATCHES = {
+  '19.0.0': '19.0.1',
+  '19.1.0': '19.1.2',
+  '19.1.1': '19.1.2',
+  '19.2.0': '19.2.1',
+};
+
+// Core React packages affected by this CVE
+const REACT_CORE_PACKAGES = ['react', 'react-dom'];
+
+function isReactVulnerable(version) {
+  const cleaned = cleanVersion(version);
+  return REACT_PATCHES.hasOwnProperty(cleaned);
+}
+
+function getReactPatchedVersion(version) {
+  const cleaned = cleanVersion(version);
+  return REACT_PATCHES[cleaned] || null;
+}
+
+module.exports = {
+  // Metadata
+  id: 'CVE-2025-55182',
+  name: 'React Server Components RCE',
+  severity: 'critical',
+  description: 'Pre-authentication remote code execution via unsafe deserialization in React Server Components',
+
+  // Packages this CVE applies to
+  packages: REACT_CORE_PACKAGES,
+
+  // Check if a specific package@version is vulnerable
+  isVulnerable(packageName, version) {
+    if (REACT_CORE_PACKAGES.includes(packageName)) {
+      return { vulnerable: isReactVulnerable(version), reason: 'react-core-version-check' };
+    }
+    return { vulnerable: false, reason: 'not-applicable' };
+  },
+
+  // Get the minimum version that fixes this CVE
+  getPatchedVersion(packageName, version) {
+    if (REACT_CORE_PACKAGES.includes(packageName)) {
+      const patched = getReactPatchedVersion(version);
+      return patched ? { recommended: patched } : null;
+    }
+    return null;
+  },
+};

--- a/lib/vulnerabilities/cve-2025-55182.js
+++ b/lib/vulnerabilities/cve-2025-55182.js
@@ -1,18 +1,26 @@
 /**
  * CVE-2025-55182: React Server Components RCE
  * @see https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components
+ * @see https://www.facebook.com/security/advisories/cve-2025-55182
  *
  * Affected packages:
  * - react: 19.0.0, 19.1.0, 19.1.1, 19.2.0
  * - react-dom: 19.0.0, 19.1.0, 19.1.1, 19.2.0
- * - react-server-dom-webpack: 19.0.0, 19.1.0-19.1.1, 19.2.0
- * - react-server-dom-parcel: 19.0.0, 19.1.0-19.1.1, 19.2.0
- * - react-server-dom-turbopack: 19.0.0, 19.1.0-19.1.1, 19.2.0
+ * - react-server-dom-webpack: 19.0.0, 19.1.0, 19.1.1, 19.2.0
+ * - react-server-dom-parcel: 19.0.0, 19.1.0, 19.1.1, 19.2.0
+ * - react-server-dom-turbopack: 19.0.0, 19.1.0, 19.1.1, 19.2.0
+ *
+ * Note: This CVE affects React Server Components across all bundlers.
  */
 
 const { cleanVersion } = require('../utils/version');
 
-// Vulnerable versions and their patches for React packages
+// React packages vulnerable to this CVE
+const REACT_VULNERABLE_VERSIONS = [
+  '19.0.0', '19.1.0', '19.1.1', '19.2.0',
+];
+
+// React package patches
 const REACT_PATCHES = {
   '19.0.0': '19.0.1',
   '19.1.0': '19.1.2',
@@ -32,7 +40,7 @@ const REACT_PACKAGES = ['react', 'react-dom', ...REACT_RSC_PACKAGES];
 
 function isReactVulnerable(version) {
   const cleaned = cleanVersion(version);
-  return REACT_PATCHES.hasOwnProperty(cleaned);
+  return REACT_VULNERABLE_VERSIONS.includes(cleaned);
 }
 
 function getReactPatchedVersion(version) {

--- a/lib/vulnerabilities/cve-2025-55182.js
+++ b/lib/vulnerabilities/cve-2025-55182.js
@@ -20,12 +20,12 @@ const REACT_VULNERABLE_VERSIONS = [
   '19.0.0', '19.1.0', '19.1.1', '19.2.0',
 ];
 
-// React package patches
+// React package patches (must patch beyond CVE-2025-55184/55183 vulnerabilities)
 const REACT_PATCHES = {
-  '19.0.0': '19.0.1',
-  '19.1.0': '19.1.2',
-  '19.1.1': '19.1.2',
-  '19.2.0': '19.2.1',
+  '19.0.0': '19.0.2',
+  '19.1.0': '19.1.3',
+  '19.1.1': '19.1.3',
+  '19.2.0': '19.2.2',
 };
 
 // React Server Components packages affected by this CVE

--- a/lib/vulnerabilities/cve-2025-55182.js
+++ b/lib/vulnerabilities/cve-2025-55182.js
@@ -1,15 +1,18 @@
 /**
- * CVE-2025-55182: React Server Components Vulnerability
+ * CVE-2025-55182: React Server Components RCE
  * @see https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components
  *
  * Affected packages:
  * - react: 19.0.0, 19.1.0, 19.1.1, 19.2.0
  * - react-dom: 19.0.0, 19.1.0, 19.1.1, 19.2.0
+ * - react-server-dom-webpack: 19.0.0, 19.1.0-19.1.1, 19.2.0
+ * - react-server-dom-parcel: 19.0.0, 19.1.0-19.1.1, 19.2.0
+ * - react-server-dom-turbopack: 19.0.0, 19.1.0-19.1.1, 19.2.0
  */
 
 const { cleanVersion } = require('../utils/version');
 
-// Vulnerable versions and their patches for React core packages
+// Vulnerable versions and their patches for React packages
 const REACT_PATCHES = {
   '19.0.0': '19.0.1',
   '19.1.0': '19.1.2',
@@ -17,8 +20,15 @@ const REACT_PATCHES = {
   '19.2.0': '19.2.1',
 };
 
-// Core React packages affected by this CVE
-const REACT_CORE_PACKAGES = ['react', 'react-dom'];
+// React Server Components packages affected by this CVE
+const REACT_RSC_PACKAGES = [
+  'react-server-dom-webpack',
+  'react-server-dom-parcel',
+  'react-server-dom-turbopack',
+];
+
+// All packages affected by this CVE
+const REACT_PACKAGES = ['react', 'react-dom', ...REACT_RSC_PACKAGES];
 
 function isReactVulnerable(version) {
   const cleaned = cleanVersion(version);
@@ -38,19 +48,19 @@ module.exports = {
   description: 'Pre-authentication remote code execution via unsafe deserialization in React Server Components',
 
   // Packages this CVE applies to
-  packages: REACT_CORE_PACKAGES,
+  packages: REACT_PACKAGES,
 
   // Check if a specific package@version is vulnerable
   isVulnerable(packageName, version) {
-    if (REACT_CORE_PACKAGES.includes(packageName)) {
-      return { vulnerable: isReactVulnerable(version), reason: 'react-core-version-check' };
+    if (REACT_PACKAGES.includes(packageName)) {
+      return { vulnerable: isReactVulnerable(version), reason: 'react-version-check' };
     }
     return { vulnerable: false, reason: 'not-applicable' };
   },
 
   // Get the minimum version that fixes this CVE
   getPatchedVersion(packageName, version) {
-    if (REACT_CORE_PACKAGES.includes(packageName)) {
+    if (REACT_PACKAGES.includes(packageName)) {
       const patched = getReactPatchedVersion(version);
       return patched ? { recommended: patched } : null;
     }

--- a/lib/vulnerabilities/cve-2025-55183.js
+++ b/lib/vulnerabilities/cve-2025-55183.js
@@ -1,18 +1,14 @@
 /**
  * CVE-2025-55183: Source Code Exposure in React Server Components
  * @see https://vercel.com/kb/bulletin/cve-2025-55184-and-cve-2025-55183
+ * @see https://www.facebook.com/security/advisories/cve-2025-55183
+ * @see https://react.dev/blog/2025/12/11/denial-of-service-and-source-code-exposure-in-react-server-components
  *
- * Affected versions:
- * - Next.js 15.0.x before 15.0.6
- * - Next.js 15.1.x before 15.1.10
- * - Next.js 15.2.x before 15.2.7
- * - Next.js 15.3.x before 15.3.7
- * - Next.js 15.4.x before 15.4.9
- * - Next.js 15.5.x before 15.5.8
- * - Next.js 15.x canary before 15.6.0-canary.59
- * - Next.js 16.0.x before 16.0.9
- * - Next.js 16.x canary before 16.1.0-canary.18
- * - React RSC packages 19.0.0 through 19.2.1
+ * Affected packages:
+ * - next: various 15.x/16.x versions (App Router only)
+ * - react-server-dom-webpack: 19.0.0 through 19.2.1
+ * - react-server-dom-parcel: 19.0.0 through 19.2.1
+ * - react-server-dom-turbopack: 19.0.0 through 19.2.1
  *
  * Note: Next.js 13.x and 14.x are NOT affected by this CVE.
  * Note: Next.js Pages Router applications are not affected.

--- a/lib/vulnerabilities/cve-2025-55184.js
+++ b/lib/vulnerabilities/cve-2025-55184.js
@@ -1,20 +1,14 @@
 /**
  * CVE-2025-55184: Denial of Service in React Server Components
  * @see https://vercel.com/kb/bulletin/cve-2025-55184-and-cve-2025-55183
+ * @see https://www.facebook.com/security/advisories/cve-2025-55184
+ * @see https://react.dev/blog/2025/12/11/denial-of-service-and-source-code-exposure-in-react-server-components
  *
- * Affected versions:
- * - Next.js 13.x (>= 13.3) - upgrade to 14.2.34
- * - Next.js 14.x before 14.2.34
- * - Next.js 15.0.x before 15.0.6
- * - Next.js 15.1.x before 15.1.10
- * - Next.js 15.2.x before 15.2.7
- * - Next.js 15.3.x before 15.3.7
- * - Next.js 15.4.x before 15.4.9
- * - Next.js 15.5.x before 15.5.8
- * - Next.js 15.x canary before 15.6.0-canary.59
- * - Next.js 16.0.x before 16.0.9
- * - Next.js 16.x canary before 16.1.0-canary.18
- * - React RSC packages 19.0.0 through 19.2.1
+ * Affected packages:
+ * - next: 13.x (>= 13.3), 14.x, 15.x, 16.x versions (App Router only)
+ * - react-server-dom-webpack: 19.0.0 through 19.2.1
+ * - react-server-dom-parcel: 19.0.0 through 19.2.1
+ * - react-server-dom-turbopack: 19.0.0 through 19.2.1
  *
  * Note: Next.js Pages Router applications are not affected.
  */

--- a/lib/vulnerabilities/cve-2025-66478.js
+++ b/lib/vulnerabilities/cve-2025-66478.js
@@ -1,10 +1,12 @@
 /**
- * CVE-2025-66478: React2Shell
+ * CVE-2025-66478: React2Shell (Next.js)
  * @see https://vercel.com/kb/bulletin/react2shell
+ * @see https://nextjs.org/blog/CVE-2025-66478
  *
  * Affected packages:
  * - next: 14.3.0-canary.77 through various 15.x/16.x versions
- * - react-server-dom-webpack, react-server-dom-parcel, react-server-dom-turbopack: specific 19.x versions
+ *
+ * Note: Next.js Pages Router applications are not affected.
  */
 
 const { parseVersion, compareVersions, cleanVersion } = require('../utils/version');

--- a/lib/vulnerabilities/cve-2025-67779.js
+++ b/lib/vulnerabilities/cve-2025-67779.js
@@ -1,26 +1,21 @@
 /**
- * CVE-2025-67779: Denial of Service with Server Components - Incomplete Fix Follow-Up
+ * CVE-2025-67779: DoS Incomplete Fix Follow-Up
  * @see https://github.com/advisories/GHSA-5j59-xgg2-r9c4
  * @see https://www.cve.org/CVERecord?id=CVE-2025-67779
+ * @see https://www.facebook.com/security/advisories/cve-2025-67779
+ * @see https://react.dev/blog/2025/12/11/denial-of-service-and-source-code-exposure-in-react-server-components
  *
- *
- * Affected versions:
- * - Next.js 13.x (>= 13.3) - upgrade to 14.2.35
- * - Next.js 14.x before 14.2.35
- * - Next.js 15.0.x before 15.0.7
- * - Next.js 15.1.x before 15.1.11
- * - Next.js 15.2.x before 15.2.8
- * - Next.js 15.3.x before 15.3.8
- * - Next.js 15.4.x before 15.4.10
- * - Next.js 15.5.x before 15.5.9
- * - Next.js 15.x canary before 15.6.0-canary.60
- * - Next.js 16.0.x before 16.0.10
- * - Next.js 16.x canary before 16.1.0-canary.19
+ * Affected packages:
+ * - next: 13.x (>= 13.3), 14.x, 15.x, 16.x versions (App Router only)
+ * - react-server-dom-webpack: 19.0.2, 19.1.3, 19.2.2
+ * - react-server-dom-parcel: 19.0.2, 19.1.3, 19.2.2
+ * - react-server-dom-turbopack: 19.0.2, 19.1.3, 19.2.2
  *
  * Note: Next.js Pages Router applications are not affected.
+ * Note: Incomplete fix follow-up for CVE-2025-55184.
  */
 
-const { parseVersion, compareVersions } = require('../utils/version');
+const { parseVersion, compareVersions, cleanVersion } = require('../utils/version');
 
 // Patched versions for Next.js 15.x and 16.x stable releases
 const NEXT_PATCHED_VERSIONS = {
@@ -38,6 +33,24 @@ const NEXT_CANARY_PATCHES = {
   15: '15.6.0-canary.60',
   16: '16.1.0-canary.19',
 };
+
+// React Server Components vulnerable versions (19.0.2, 19.1.3, 19.2.2)
+const REACT_RSC_VULNERABLE_VERSIONS = [
+  '19.0.2', '19.1.3', '19.2.2',
+];
+
+// React Server Components patches
+const REACT_RSC_PATCHES = {
+  '19.0.2': '19.0.3',
+  '19.1.3': '19.1.4',
+  '19.2.2': '19.2.3',
+};
+
+const REACT_RSC_PACKAGES = [
+  'react-server-dom-webpack',
+  'react-server-dom-parcel',
+  'react-server-dom-turbopack',
+];
 
 function isNextVulnerable(version) {
   const parsed = parseVersion(version);
@@ -125,6 +138,16 @@ function isNextVulnerable(version) {
   return { vulnerable: false, reason: 'future-version' };
 }
 
+function isReactRscVulnerable(version) {
+  const cleaned = cleanVersion(version);
+  return REACT_RSC_VULNERABLE_VERSIONS.includes(cleaned);
+}
+
+function getReactRscPatchedVersion(version) {
+  const cleaned = cleanVersion(version);
+  return REACT_RSC_PATCHES[cleaned] || null;
+}
+
 function getNextPatchedVersion(version) {
   const parsed = parseVersion(version);
   if (!parsed) return null;
@@ -184,11 +207,14 @@ module.exports = {
   name: 'DoS Incomplete Fix Follow-Up',
   severity: 'high',
   description: 'Incomplete fix for CVE-2025-55184 DoS via malicious RSC payload causing infinite loop',
-  packages: ['next'],
+  packages: ['next', ...REACT_RSC_PACKAGES],
 
   isVulnerable(packageName, version) {
     if (packageName === 'next') {
       return isNextVulnerable(version);
+    }
+    if (REACT_RSC_PACKAGES.includes(packageName)) {
+      return { vulnerable: isReactRscVulnerable(version), reason: 'rsc-version-check' };
     }
     return { vulnerable: false, reason: 'not-applicable' };
   },
@@ -196,6 +222,10 @@ module.exports = {
   getPatchedVersion(packageName, version) {
     if (packageName === 'next') {
       return getNextPatchedVersion(version);
+    }
+    if (REACT_RSC_PACKAGES.includes(packageName)) {
+      const patched = getReactRscPatchedVersion(version);
+      return patched ? { recommended: patched } : null;
     }
     return null;
   },

--- a/lib/vulnerabilities/index.js
+++ b/lib/vulnerabilities/index.js
@@ -7,6 +7,7 @@ const vulnerabilities = [
   require('./cve-2025-66478'),  // React2Shell - RCE (critical)
   require('./cve-2025-55184'),  // DoS (high)
   require('./cve-2025-55183'),  // Source Code Exposure (medium)
+  require('./cve-2025-55182'),  // React Core RCE (critical)
   require('./cve-2025-67779'),  // DoS Incomplete Fix Follow-Up (high)
 ];
 

--- a/lib/vulnerabilities/index.js
+++ b/lib/vulnerabilities/index.js
@@ -4,11 +4,11 @@
  */
 
 const vulnerabilities = [
-  require('./cve-2025-66478'),  // React2Shell - RCE (critical)
-  require('./cve-2025-55184'),  // DoS (high)
-  require('./cve-2025-55183'),  // Source Code Exposure (medium)
-  require('./cve-2025-55182'),  // React Core RCE (critical)
-  require('./cve-2025-67779'),  // DoS Incomplete Fix Follow-Up (high)
+  require('./cve-2025-66478'),  // React2Shell: RCE in Next.js App Router (critical)
+  require('./cve-2025-55184'),  // DoS: Infinite loops in React Server Components (high)
+  require('./cve-2025-55183'),  // Source Code Exposure: Server Functions leak source (medium)
+  require('./cve-2025-55182'),  // RCE: Unsafe deserialization in React Server Components (critical)
+  require('./cve-2025-67779'),  // DoS Follow-up: Incomplete fix for CVE-2025-55184 (high)
 ];
 
 // Get all unique package names across all vulnerabilities

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/vercel-labs/fix-react2shell-next.git"
   },
-  "description": "Fix the React 2 Shell vulnerability (CVE-2025-66478) in Next.js apps with one command",
+  "description": "Fix multiple React/Next.js security vulnerabilities in Next.js apps with one command",
   "main": "index.js",
   "bin": {
     "fix-react2shell-next": "./bin/cli.js"

--- a/test/cve-2025-55182.test.js
+++ b/test/cve-2025-55182.test.js
@@ -16,9 +16,9 @@ const { describe, it } = require('node:test');
 const assert = require('node:assert');
 const cve55182 = require('../lib/vulnerabilities/cve-2025-55182');
 
-describe('CVE-2025-55182 (React Core Security Issue)', () => {
+describe('CVE-2025-55182 (React Server Components RCE)', () => {
   describe('React package vulnerability detection', () => {
-    const reactPackages = ['react', 'react-dom'];
+    const reactPackages = ['react', 'react-dom', 'react-server-dom-webpack', 'react-server-dom-parcel', 'react-server-dom-turbopack'];
 
     describe('vulnerable React 19 versions', () => {
       const vulnerableVersions = ['19.0.0', '19.1.0', '19.1.1', '19.2.0'];
@@ -88,6 +88,24 @@ describe('CVE-2025-55182 (React Core Security Issue)', () => {
         const result = cve55182.getPatchedVersion('react-dom', '19.0.0');
         assert.ok(result, 'Should return a patch recommendation');
         assert.strictEqual(result.recommended, '19.0.1');
+      });
+
+      it('should work for react-server-dom-webpack', () => {
+        const result = cve55182.getPatchedVersion('react-server-dom-webpack', '19.0.0');
+        assert.ok(result, 'Should return a patch recommendation');
+        assert.strictEqual(result.recommended, '19.0.1');
+      });
+
+      it('should work for react-server-dom-parcel', () => {
+        const result = cve55182.getPatchedVersion('react-server-dom-parcel', '19.1.0');
+        assert.ok(result, 'Should return a patch recommendation');
+        assert.strictEqual(result.recommended, '19.1.2');
+      });
+
+      it('should work for react-server-dom-turbopack', () => {
+        const result = cve55182.getPatchedVersion('react-server-dom-turbopack', '19.2.0');
+        assert.ok(result, 'Should return a patch recommendation');
+        assert.strictEqual(result.recommended, '19.2.1');
       });
     });
 

--- a/test/cve-2025-55182.test.js
+++ b/test/cve-2025-55182.test.js
@@ -1,15 +1,20 @@
 /**
- * Tests for CVE-2025-55182 (React Core Security Issue)
+ * Tests for CVE-2025-55182 (React Server Components RCE)
  *
  * Affected packages:
  * - react: 19.0.0, 19.1.0, 19.1.1, 19.2.0
  * - react-dom: 19.0.0, 19.1.0, 19.1.1, 19.2.0
+ * - react-server-dom-webpack: 19.0.0, 19.1.0, 19.1.1, 19.2.0
+ * - react-server-dom-parcel: 19.0.0, 19.1.0, 19.1.1, 19.2.0
+ * - react-server-dom-turbopack: 19.0.0, 19.1.0, 19.1.1, 19.2.0
  *
  * Patched versions:
- * - 19.0.0 → 19.0.1
- * - 19.1.0 → 19.1.2
- * - 19.1.1 → 19.1.2
- * - 19.2.0 → 19.2.1
+ * - 19.0.0 → 19.0.2
+ * - 19.1.0 → 19.1.3
+ * - 19.1.1 → 19.1.3
+ * - 19.2.0 → 19.2.2
+ *
+ * Note: This CVE affects React Server Components across all bundlers.
  */
 
 const { describe, it } = require('node:test');
@@ -60,52 +65,52 @@ describe('CVE-2025-55182 (React Server Components RCE)', () => {
     });
 
     describe('getPatchedVersion recommendations', () => {
-      it('should recommend 19.0.1 for react@19.0.0', () => {
+      it('should recommend 19.0.2 for react@19.0.0', () => {
         const result = cve55182.getPatchedVersion('react', '19.0.0');
         assert.ok(result, 'Should return a patch recommendation');
-        assert.strictEqual(result.recommended, '19.0.1');
+        assert.strictEqual(result.recommended, '19.0.2');
       });
 
-      it('should recommend 19.1.2 for react@19.1.0', () => {
+      it('should recommend 19.1.3 for react@19.1.0', () => {
         const result = cve55182.getPatchedVersion('react', '19.1.0');
         assert.ok(result, 'Should return a patch recommendation');
-        assert.strictEqual(result.recommended, '19.1.2');
+        assert.strictEqual(result.recommended, '19.1.3');
       });
 
-      it('should recommend 19.1.2 for react@19.1.1', () => {
+      it('should recommend 19.1.3 for react@19.1.1', () => {
         const result = cve55182.getPatchedVersion('react', '19.1.1');
         assert.ok(result, 'Should return a patch recommendation');
-        assert.strictEqual(result.recommended, '19.1.2');
+        assert.strictEqual(result.recommended, '19.1.3');
       });
 
-      it('should recommend 19.2.1 for react@19.2.0', () => {
+      it('should recommend 19.2.2 for react@19.2.0', () => {
         const result = cve55182.getPatchedVersion('react', '19.2.0');
         assert.ok(result, 'Should return a patch recommendation');
-        assert.strictEqual(result.recommended, '19.2.1');
+        assert.strictEqual(result.recommended, '19.2.2');
       });
 
       it('should work for react-dom as well', () => {
         const result = cve55182.getPatchedVersion('react-dom', '19.0.0');
         assert.ok(result, 'Should return a patch recommendation');
-        assert.strictEqual(result.recommended, '19.0.1');
+        assert.strictEqual(result.recommended, '19.0.2');
       });
 
       it('should work for react-server-dom-webpack', () => {
         const result = cve55182.getPatchedVersion('react-server-dom-webpack', '19.0.0');
         assert.ok(result, 'Should return a patch recommendation');
-        assert.strictEqual(result.recommended, '19.0.1');
+        assert.strictEqual(result.recommended, '19.0.2');
       });
 
       it('should work for react-server-dom-parcel', () => {
         const result = cve55182.getPatchedVersion('react-server-dom-parcel', '19.1.0');
         assert.ok(result, 'Should return a patch recommendation');
-        assert.strictEqual(result.recommended, '19.1.2');
+        assert.strictEqual(result.recommended, '19.1.3');
       });
 
       it('should work for react-server-dom-turbopack', () => {
         const result = cve55182.getPatchedVersion('react-server-dom-turbopack', '19.2.0');
         assert.ok(result, 'Should return a patch recommendation');
-        assert.strictEqual(result.recommended, '19.2.1');
+        assert.strictEqual(result.recommended, '19.2.2');
       });
     });
 

--- a/test/cve-2025-55182.test.js
+++ b/test/cve-2025-55182.test.js
@@ -1,0 +1,117 @@
+/**
+ * Tests for CVE-2025-55182 (React Core Security Issue)
+ *
+ * Affected packages:
+ * - react: 19.0.0, 19.1.0, 19.1.1, 19.2.0
+ * - react-dom: 19.0.0, 19.1.0, 19.1.1, 19.2.0
+ *
+ * Patched versions:
+ * - 19.0.0 → 19.0.1
+ * - 19.1.0 → 19.1.2
+ * - 19.1.1 → 19.1.2
+ * - 19.2.0 → 19.2.1
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const cve55182 = require('../lib/vulnerabilities/cve-2025-55182');
+
+describe('CVE-2025-55182 (React Core Security Issue)', () => {
+  describe('React package vulnerability detection', () => {
+    const reactPackages = ['react', 'react-dom'];
+
+    describe('vulnerable React 19 versions', () => {
+      const vulnerableVersions = ['19.0.0', '19.1.0', '19.1.1', '19.2.0'];
+
+      for (const pkg of reactPackages) {
+        for (const version of vulnerableVersions) {
+          it(`should flag ${pkg}@${version} as vulnerable`, () => {
+            const result = cve55182.isVulnerable(pkg, version);
+            assert.strictEqual(result.vulnerable, true, `Expected ${pkg}@${version} to be vulnerable`);
+          });
+        }
+      }
+    });
+
+    describe('patched React versions', () => {
+      const patchedVersions = ['19.0.1', '19.1.2', '19.2.1'];
+
+      for (const pkg of reactPackages) {
+        for (const version of patchedVersions) {
+          it(`should NOT flag ${pkg}@${version} as vulnerable`, () => {
+            const result = cve55182.isVulnerable(pkg, version);
+            assert.strictEqual(result.vulnerable, false, `Expected ${pkg}@${version} to NOT be vulnerable`);
+          });
+        }
+      }
+    });
+
+    describe('React versions before 19 are not affected', () => {
+      const safeVersions = ['18.0.0', '18.2.0', '18.3.1'];
+
+      for (const pkg of reactPackages) {
+        for (const version of safeVersions) {
+          it(`should NOT flag ${pkg}@${version} as vulnerable`, () => {
+            const result = cve55182.isVulnerable(pkg, version);
+            assert.strictEqual(result.vulnerable, false, `Expected ${pkg}@${version} to NOT be vulnerable`);
+          });
+        }
+      }
+    });
+
+    describe('getPatchedVersion recommendations', () => {
+      it('should recommend 19.0.1 for react@19.0.0', () => {
+        const result = cve55182.getPatchedVersion('react', '19.0.0');
+        assert.ok(result, 'Should return a patch recommendation');
+        assert.strictEqual(result.recommended, '19.0.1');
+      });
+
+      it('should recommend 19.1.2 for react@19.1.0', () => {
+        const result = cve55182.getPatchedVersion('react', '19.1.0');
+        assert.ok(result, 'Should return a patch recommendation');
+        assert.strictEqual(result.recommended, '19.1.2');
+      });
+
+      it('should recommend 19.1.2 for react@19.1.1', () => {
+        const result = cve55182.getPatchedVersion('react', '19.1.1');
+        assert.ok(result, 'Should return a patch recommendation');
+        assert.strictEqual(result.recommended, '19.1.2');
+      });
+
+      it('should recommend 19.2.1 for react@19.2.0', () => {
+        const result = cve55182.getPatchedVersion('react', '19.2.0');
+        assert.ok(result, 'Should return a patch recommendation');
+        assert.strictEqual(result.recommended, '19.2.1');
+      });
+
+      it('should work for react-dom as well', () => {
+        const result = cve55182.getPatchedVersion('react-dom', '19.0.0');
+        assert.ok(result, 'Should return a patch recommendation');
+        assert.strictEqual(result.recommended, '19.0.1');
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle version with caret prefix', () => {
+        const result = cve55182.isVulnerable('react', '^19.0.0');
+        assert.strictEqual(result.vulnerable, true);
+      });
+
+      it('should handle version with tilde prefix', () => {
+        const result = cve55182.isVulnerable('react', '~19.0.1');
+        assert.strictEqual(result.vulnerable, false);
+      });
+
+      it('should return not vulnerable for unknown packages', () => {
+        const result = cve55182.isVulnerable('next', '19.0.0');
+        assert.strictEqual(result.vulnerable, false);
+        assert.strictEqual(result.reason, 'not-applicable');
+      });
+
+      it('should handle unparseable versions gracefully', () => {
+        const result = cve55182.isVulnerable('react', 'invalid');
+        assert.strictEqual(result.vulnerable, false);
+      });
+    });
+  });
+});

--- a/test/cve-2025-55183.test.js
+++ b/test/cve-2025-55183.test.js
@@ -1,22 +1,24 @@
 /**
  * Tests for CVE-2025-55183 (Source Code Exposure) vulnerability detection
  *
- * Source Code Exposure affects ONLY Next.js 15.x and 16.x (NOT 13.x or 14.x).
+ * Affected packages:
+ * - next: various 15.x/16.x versions (App Router only)
+ * - react-server-dom-webpack: 19.0.0 through 19.2.1
+ * - react-server-dom-parcel: 19.0.0 through 19.2.1
+ * - react-server-dom-turbopack: 19.0.0 through 19.2.1
  *
- * Affected versions:
- * - Next.js 15.0.x before 15.0.6
- * - Next.js 15.1.x before 15.1.10
- * - Next.js 15.2.x before 15.2.7
- * - Next.js 15.3.x before 15.3.7
- * - Next.js 15.4.x before 15.4.9
- * - Next.js 15.5.x before 15.5.8
- * - Next.js 15.x canary before 15.6.0-canary.59
- * - Next.js 16.0.x before 16.0.9
- * - Next.js 16.x canary before 16.1.0-canary.17
- * - React RSC packages 19.0.0 through 19.2.1
+ * Patched versions:
+ * - Next.js 15.0.x → 15.0.6
+ * - Next.js 15.1.x → 15.1.10
+ * - Next.js 15.2.x → 15.2.7
+ * - Next.js 15.3.x → 15.3.7
+ * - Next.js 15.4.x → 15.4.9
+ * - Next.js 15.5.x → 15.5.8
+ * - Next.js 16.0.x → 16.0.9
+ * - React Server Components → 19.0.2, 19.1.3, 19.2.2
  *
- * Note: Next.js 13.x and 14.x are NOT affected by this CVE (per bulletin table).
- * Note: Pages Router applications are not affected.
+ * Note: Next.js 13.x and 14.x are NOT affected by this CVE.
+ * Note: Next.js Pages Router applications are not affected.
  */
 
 const { describe, it } = require('node:test');

--- a/test/cve-2025-55184.test.js
+++ b/test/cve-2025-55184.test.js
@@ -1,30 +1,27 @@
 /**
  * Tests for CVE-2025-55184 (Denial of Service) vulnerability detection
  *
- * These vulnerabilities affect React versions 19.0.0 through 19.2.1
- * and Next.js versions 13.x through 16.x.
+ * Affected packages:
+ * - next: 13.x (>= 13.3), 14.x, 15.x, 16.x versions (App Router only)
+ * - react-server-dom-webpack: 19.0.0 through 19.2.1
+ * - react-server-dom-parcel: 19.0.0 through 19.2.1
+ * - react-server-dom-turbopack: 19.0.0 through 19.2.1
  *
- * Affected versions (DoS):
- * - Next.js >= 13.3 (App Router introduced)
- * - Next.js 14.x
- * - Next.js 15.0.x through 15.5.x
- * - Next.js 16.0.x
+ * Patched versions:
+ * - Next.js >=13.3 → Upgrade to 14.2.34
+ * - Next.js 14.x → 14.2.34
+ * - Next.js 15.0.x → 15.0.6
+ * - Next.js 15.1.x → 15.1.10
+ * - Next.js 15.2.x → 15.2.7
+ * - Next.js 15.3.x → 15.3.7
+ * - Next.js 15.4.x → 15.4.9
+ * - Next.js 15.5.x → 15.5.8
+ * - Next.js 15.x canary → 15.6.0-canary.59
+ * - Next.js 16.0.x → 16.0.9
+ * - Next.js 16.x canary → 16.1.0-canary.18
+ * - React Server Components → 19.0.2, 19.1.3, 19.2.2
  *
- * Patched versions (from the bulletin):
- * | Version              | Fixed In              |
- * | Next.js >=13.3       | Upgrade to 14.2.34    |
- * | Next.js 14.x         | 14.2.34               |
- * | Next.js 15.0.x       | 15.0.6                |
- * | Next.js 15.1.x       | 15.1.10               |
- * | Next.js 15.2.x       | 15.2.7                |
- * | Next.js 15.3.x       | 15.3.7                |
- * | Next.js 15.4.x       | 15.4.9                |
- * | Next.js 15.5.x       | 15.5.8                |
- * | Next.js 15.x canary  | 15.6.0-canary.59      |
- * | Next.js 16.0.x       | 16.0.9                |
- * | Next.js 16.0.x canary| 16.1.0-canary.18      |
- *
- * Note: Pages Router applications are not affected.
+ * Note: Next.js Pages Router applications are not affected.
  */
 
 const { describe, it } = require('node:test');

--- a/test/cve-2025-66478.test.js
+++ b/test/cve-2025-66478.test.js
@@ -1,27 +1,22 @@
 /**
  * Tests for CVE-2025-66478 (React2Shell) vulnerability detection
  *
- * Affected Next.js versions:
- * - 15.0.0 through 16.0.6
- * - 14 canary versions after 14.3.0-canary.76
+ * Affected packages:
+ * - next: 14.3.0-canary.77 through various 15.x/16.x versions
  *
- * Patched versions (from the bulletin):
- * | Vulnerable version | Patched release |
- * | Next.js 15.0.x     | 15.0.5          |
- * | Next.js 15.1.x     | 15.1.9          |
- * | Next.js 15.2.x     | 15.2.6          |
- * | Next.js 15.3.x     | 15.3.6          |
- * | Next.js 15.4.x     | 15.4.8          |
- * | Next.js 15.5.x     | 15.5.7          |
- * | Next.js 16.0.x     | 16.0.7          |
- * | 14 canaries after 14.3.0-canary.76 | Downgrade to 14.3.0-canary.76 |
- * | 15 canaries before 15.6.0-canary.58 | 15.6.0-canary.58 |
- * | 16 canaries before 16.1.0-canary.12 | 16.1.0-canary.12 |
+ * Patched versions:
+ * - Next.js 15.0.x → 15.0.5
+ * - Next.js 15.1.x → 15.1.9
+ * - Next.js 15.2.x → 15.2.6
+ * - Next.js 15.3.x → 15.3.6
+ * - Next.js 15.4.x → 15.4.8
+ * - Next.js 15.5.x → 15.5.7
+ * - Next.js 16.0.x → 16.0.7
+ * - 14.x canaries after 14.3.0-canary.76 → 14.3.0-canary.76
+ * - 15.x canaries before 15.6.0-canary.58 → 15.6.0-canary.58
+ * - 16.x canaries before 16.1.0-canary.12 → 16.1.0-canary.12
  *
- * React RSC packages affected:
- * - react-server-dom-webpack
- * - react-server-dom-parcel
- * - react-server-dom-turbopack
+ * Note: Next.js Pages Router applications are not affected.
  */
 
 const { describe, it } = require('node:test');

--- a/test/cve-2025-67779.test.js
+++ b/test/cve-2025-67779.test.js
@@ -1,0 +1,355 @@
+/**
+ * Tests for CVE-2025-67779 (DoS Incomplete Fix Follow-Up) vulnerability detection
+ *
+ * Affected packages:
+ * - next: 13.x (>= 13.3), 14.x, 15.x, 16.x versions (App Router only)
+ * - react-server-dom-webpack: 19.0.2, 19.1.3, 19.2.2
+ * - react-server-dom-parcel: 19.0.2, 19.1.3, 19.2.2
+ * - react-server-dom-turbopack: 19.0.2, 19.1.3, 19.2.2
+ *
+ * Patched versions:
+ * - Next.js >=13.3 → Upgrade to 14.2.35
+ * - Next.js 14.x → 14.2.35
+ * - Next.js 15.0.x → 15.0.7
+ * - Next.js 15.1.x → 15.1.11
+ * - Next.js 15.2.x → 15.2.8
+ * - Next.js 15.3.x → 15.3.8
+ * - Next.js 15.4.x → 15.4.10
+ * - Next.js 15.5.x → 15.5.9
+ * - Next.js 15.x canary → 15.6.0-canary.60
+ * - Next.js 16.0.x → 16.0.10
+ * - Next.js 16.x canary → 16.1.0-canary.19
+ * - React Server Components → 19.0.3, 19.1.4, 19.2.3
+ *
+ * Note: Next.js Pages Router applications are not affected.
+ * Note: Incomplete fix follow-up for CVE-2025-55184.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const cve67779 = require('../lib/vulnerabilities/cve-2025-67779');
+
+describe('CVE-2025-67779 (DoS Incomplete Fix Follow-Up)', () => {
+  describe('Next.js vulnerability detection', () => {
+    describe('versions NOT affected (before App Router - 13.3)', () => {
+      const safeVersions = [
+        '12.0.0',
+        '12.3.4',
+        '13.0.0',
+        '13.1.0',
+        '13.2.0',
+        '13.2.9', // last version before App Router
+      ];
+
+      for (const version of safeVersions) {
+        it(`should NOT flag ${version} as vulnerable (before App Router)`, () => {
+          const result = cve67779.isVulnerable('next', version);
+          assert.strictEqual(result.vulnerable, false, `Expected ${version} to NOT be vulnerable`);
+        });
+      }
+    });
+
+    describe('Next.js 13.x (>= 13.3) - vulnerable, must upgrade to 14.2.35', () => {
+      const vulnerableVersions = [
+        '13.3.0',  // App Router introduced
+        '13.4.0',
+        '13.5.0',
+        '13.5.6',
+      ];
+
+      for (const version of vulnerableVersions) {
+        it(`should flag ${version} as vulnerable`, () => {
+          const result = cve67779.isVulnerable('next', version);
+          assert.strictEqual(result.vulnerable, true, `Expected ${version} to be vulnerable`);
+        });
+
+        it(`should recommend 14.2.35 for ${version}`, () => {
+          const result = cve67779.getPatchedVersion('next', version);
+          assert.strictEqual(result.recommended, '14.2.35');
+        });
+      }
+    });
+
+    describe('Next.js 14.x - vulnerable before 14.2.35', () => {
+      const vulnerableVersions = [
+        '14.0.0',
+        '14.1.0',
+        '14.2.0',
+        '14.2.34',
+      ];
+
+      for (const version of vulnerableVersions) {
+        it(`should flag ${version} as vulnerable`, () => {
+          const result = cve67779.isVulnerable('next', version);
+          assert.strictEqual(result.vulnerable, true, `Expected ${version} to be vulnerable`);
+        });
+      }
+
+      it('should NOT flag 14.2.35 as vulnerable (patched)', () => {
+        const result = cve67779.isVulnerable('next', '14.2.35');
+        assert.strictEqual(result.vulnerable, false);
+      });
+
+      it('should NOT flag 14.2.36 as vulnerable', () => {
+        const result = cve67779.isVulnerable('next', '14.2.36');
+        assert.strictEqual(result.vulnerable, false);
+      });
+    });
+
+    describe('Next.js 15.x - vulnerable versions', () => {
+      const vulnerableVersions = [
+        '15.0.0',
+        '15.0.6',  // previous patch for DoS, not enough for this follow-up
+        '15.1.0',
+        '15.1.10', // previous patch for DoS, not enough for this follow-up
+        '15.2.0',
+        '15.2.7',  // previous patch for DoS, not enough for this follow-up
+        '15.3.0',
+        '15.3.7',  // previous patch for DoS, not enough for this follow-up
+        '15.4.0',
+        '15.4.9',  // previous patch for DoS, not enough for this follow-up
+        '15.5.0',
+        '15.5.8',  // previous patch for DoS, not enough for this follow-up
+      ];
+
+      for (const version of vulnerableVersions) {
+        it(`should flag ${version} as vulnerable`, () => {
+          const result = cve67779.isVulnerable('next', version);
+          assert.strictEqual(result.vulnerable, true, `Expected ${version} to be vulnerable`);
+        });
+      }
+    });
+
+    describe('Next.js 15.x - patched versions', () => {
+      const patchedVersions = [
+        '15.0.7',
+        '15.1.11',
+        '15.2.8',
+        '15.3.8',
+        '15.4.10',
+        '15.5.9',
+      ];
+
+      for (const version of patchedVersions) {
+        it(`should NOT flag ${version} as vulnerable (patched)`, () => {
+          const result = cve67779.isVulnerable('next', version);
+          assert.strictEqual(result.vulnerable, false, `Expected ${version} to NOT be vulnerable`);
+        });
+      }
+    });
+
+    describe('Next.js 15.x canaries', () => {
+      it('should flag 15.6.0-canary.59 as vulnerable (patch is .60)', () => {
+        const result = cve67779.isVulnerable('next', '15.6.0-canary.59');
+        assert.strictEqual(result.vulnerable, true);
+      });
+
+      it('should NOT flag 15.6.0-canary.60 as vulnerable (patched)', () => {
+        const result = cve67779.isVulnerable('next', '15.6.0-canary.60');
+        assert.strictEqual(result.vulnerable, false);
+      });
+
+      it('should NOT flag 15.6.0-canary.61 as vulnerable', () => {
+        const result = cve67779.isVulnerable('next', '15.6.0-canary.61');
+        assert.strictEqual(result.vulnerable, false);
+      });
+    });
+
+    describe('Next.js 16.x - vulnerable versions', () => {
+      const vulnerableVersions = [
+        '16.0.0',
+        '16.0.9',  // previous patch for DoS, not enough for this follow-up
+      ];
+
+      for (const version of vulnerableVersions) {
+        it(`should flag ${version} as vulnerable`, () => {
+          const result = cve67779.isVulnerable('next', version);
+          assert.strictEqual(result.vulnerable, true, `Expected ${version} to be vulnerable`);
+        });
+      }
+    });
+
+    describe('Next.js 16.x - patched versions', () => {
+      it('should NOT flag 16.0.10 as vulnerable (patched)', () => {
+        const result = cve67779.isVulnerable('next', '16.0.10');
+        assert.strictEqual(result.vulnerable, false);
+      });
+
+      it('should NOT flag 16.0.11 as vulnerable', () => {
+        const result = cve67779.isVulnerable('next', '16.0.11');
+        assert.strictEqual(result.vulnerable, false);
+      });
+
+      it('should NOT flag 16.1.0 as vulnerable', () => {
+        const result = cve67779.isVulnerable('next', '16.1.0');
+        assert.strictEqual(result.vulnerable, false);
+      });
+    });
+
+    describe('Next.js 16.x canaries', () => {
+      it('should flag 16.1.0-canary.18 as vulnerable (patch is .19)', () => {
+        const result = cve67779.isVulnerable('next', '16.1.0-canary.18');
+        assert.strictEqual(result.vulnerable, true);
+      });
+
+      it('should NOT flag 16.1.0-canary.19 as vulnerable (patched)', () => {
+        const result = cve67779.isVulnerable('next', '16.1.0-canary.19');
+        assert.strictEqual(result.vulnerable, false);
+      });
+
+      it('should NOT flag 16.1.0-canary.20 as vulnerable', () => {
+        const result = cve67779.isVulnerable('next', '16.1.0-canary.20');
+        assert.strictEqual(result.vulnerable, false);
+      });
+    });
+
+    describe('Future versions (17+) - assume safe', () => {
+      it('should NOT flag 17.0.0 as vulnerable', () => {
+        const result = cve67779.isVulnerable('next', '17.0.0');
+        assert.strictEqual(result.vulnerable, false);
+      });
+    });
+  });
+
+  describe('React RSC package vulnerability detection', () => {
+    const rscPackages = [
+      'react-server-dom-webpack',
+      'react-server-dom-parcel',
+      'react-server-dom-turbopack',
+    ];
+
+    describe('vulnerable React 19 versions (19.0.2, 19.1.3, 19.2.2)', () => {
+      const vulnerableVersions = [
+        '19.0.2',
+        '19.1.3',
+        '19.2.2',
+      ];
+
+      for (const pkg of rscPackages) {
+        for (const version of vulnerableVersions) {
+          it(`should flag ${pkg}@${version} as vulnerable`, () => {
+            const result = cve67779.isVulnerable(pkg, version);
+            assert.strictEqual(result.vulnerable, true, `Expected ${pkg}@${version} to be vulnerable`);
+          });
+        }
+      }
+    });
+
+    describe('patched React RSC versions', () => {
+      const patchedVersions = ['19.0.3', '19.1.4', '19.2.3'];
+
+      for (const pkg of rscPackages) {
+        for (const version of patchedVersions) {
+          it(`should NOT flag ${pkg}@${version} as vulnerable`, () => {
+            const result = cve67779.isVulnerable(pkg, version);
+            assert.strictEqual(result.vulnerable, false, `Expected ${pkg}@${version} to NOT be vulnerable`);
+          });
+        }
+      }
+    });
+
+    describe('React versions before 19 are not affected', () => {
+      const safeVersions = ['18.0.0', '18.2.0', '18.3.1', '19.0.0', '19.0.1', '19.1.0', '19.1.1', '19.1.2', '19.2.0', '19.2.1'];
+
+      for (const pkg of rscPackages) {
+        for (const version of safeVersions) {
+          it(`should NOT flag ${pkg}@${version} as vulnerable`, () => {
+            const result = cve67779.isVulnerable(pkg, version);
+            assert.strictEqual(result.vulnerable, false, `Expected ${pkg}@${version} to NOT be vulnerable`);
+          });
+        }
+      }
+    });
+  });
+
+  describe('getPatchedVersion recommendations', () => {
+    it('should recommend 14.2.35 for 13.x (>= 13.3)', () => {
+      const result = cve67779.getPatchedVersion('next', '13.4.0');
+      assert.strictEqual(result.recommended, '14.2.35');
+    });
+
+    it('should recommend 14.2.35 for 14.x stable', () => {
+      const result = cve67779.getPatchedVersion('next', '14.1.0');
+      assert.strictEqual(result.recommended, '14.2.35');
+    });
+
+    it('should recommend 15.0.7 for 15.0.x', () => {
+      const result = cve67779.getPatchedVersion('next', '15.0.0');
+      assert.strictEqual(result.recommended, '15.0.7');
+    });
+
+    it('should recommend 15.1.11 for 15.1.x', () => {
+      const result = cve67779.getPatchedVersion('next', '15.1.0');
+      assert.strictEqual(result.recommended, '15.1.11');
+    });
+
+    it('should recommend 15.2.8 for 15.2.x', () => {
+      const result = cve67779.getPatchedVersion('next', '15.2.0');
+      assert.strictEqual(result.recommended, '15.2.8');
+    });
+
+    it('should recommend 15.3.8 for 15.3.x', () => {
+      const result = cve67779.getPatchedVersion('next', '15.3.0');
+      assert.strictEqual(result.recommended, '15.3.8');
+    });
+
+    it('should recommend 15.4.10 for 15.4.x', () => {
+      const result = cve67779.getPatchedVersion('next', '15.4.0');
+      assert.strictEqual(result.recommended, '15.4.10');
+    });
+
+    it('should recommend 15.5.9 for 15.5.x', () => {
+      const result = cve67779.getPatchedVersion('next', '15.5.0');
+      assert.strictEqual(result.recommended, '15.5.9');
+    });
+
+    it('should recommend 16.0.10 for 16.0.x', () => {
+      const result = cve67779.getPatchedVersion('next', '16.0.0');
+      assert.strictEqual(result.recommended, '16.0.10');
+    });
+
+    it('should recommend 15.6.0-canary.60 for 15.x canaries', () => {
+      const result = cve67779.getPatchedVersion('next', '15.6.0-canary.0');
+      assert.strictEqual(result.recommended, '15.6.0-canary.60');
+    });
+
+    it('should recommend 16.1.0-canary.19 for 16.x canaries', () => {
+      const result = cve67779.getPatchedVersion('next', '16.1.0-canary.0');
+      assert.strictEqual(result.recommended, '16.1.0-canary.19');
+    });
+
+    describe('React RSC patch recommendations', () => {
+      it('should recommend 19.0.3 for 19.0.2', () => {
+        const result = cve67779.getPatchedVersion('react-server-dom-webpack', '19.0.2');
+        assert.strictEqual(result.recommended, '19.0.3');
+      });
+
+      it('should recommend 19.1.4 for 19.1.3', () => {
+        const result = cve67779.getPatchedVersion('react-server-dom-webpack', '19.1.3');
+        assert.strictEqual(result.recommended, '19.1.4');
+      });
+
+      it('should recommend 19.2.3 for 19.2.2', () => {
+        const result = cve67779.getPatchedVersion('react-server-dom-webpack', '19.2.2');
+        assert.strictEqual(result.recommended, '19.2.3');
+      });
+    });
+  });
+
+  describe('metadata', () => {
+    it('should have correct CVE ID', () => {
+      assert.strictEqual(cve67779.id, 'CVE-2025-67779');
+    });
+
+    it('should have high severity', () => {
+      assert.strictEqual(cve67779.severity, 'high');
+    });
+
+    it('should include all relevant packages', () => {
+      assert.ok(cve67779.packages.includes('next'));
+      assert.ok(cve67779.packages.includes('react-server-dom-webpack'));
+      assert.ok(cve67779.packages.includes('react-server-dom-parcel'));
+      assert.ok(cve67779.packages.includes('react-server-dom-turbopack'));
+    });
+  });
+});


### PR DESCRIPTION
- Add CVE-2025-55182 detection for React Server Components RCE
- Implement CVE-2025-67779 support for DoS follow-up vulnerability  
- Remove React Server Components duplication from CVE-2025-66478
- Update all test files with consistent headers and complete coverage
- Enhance README with comprehensive CVE documentation
- Tool now handles 5 total security vulnerabilities without duplication