### PR TITLE
Fix incomplete CVE coverage - users remain vulnerable to critical CVEs

### DIFF
--- a/lib/vulnerabilities/cve-2025-55183.js
+++ b/lib/vulnerabilities/cve-2025-55183.js
@@ -12,7 +12,10 @@
  * - Next.js 15.x canary before 15.6.0-canary.59
  * - Next.js 16.0.x before 16.0.9
  * - Next.js 16.x canary before 16.1.0-canary.18
- * - React RSC packages 19.0.0 through 19.2.1
+ * - react-server-dom-webpack: 19.0.0-19.0.2, 19.1.0-19.1.3, 19.2.0-19.2.2
+ * - react-server-dom-parcel: 19.0.0-19.0.2, 19.1.0-19.1.3, 19.2.0-19.2.2
+ * - react-server-dom-turbopack: 19.0.0-19.0.2, 19.1.0-19.1.3, 19.2.0-19.2.2
+ * - React core: 19.0.0-19.2.2
  *
  * Note: Next.js 13.x and 14.x are NOT affected by this CVE.
  * Note: Next.js Pages Router applications are not affected.
@@ -37,22 +40,25 @@ const NEXT_CANARY_PATCHES = {
   16: '16.1.0-canary.18',
 };
 
-// React RSC vulnerable versions (19.0.0 through 19.2.1)
+// React RSC vulnerable versions (19.0.0 through 19.2.2)
 const REACT_RSC_VULNERABLE_VERSIONS = [
-  '19.0.0', '19.0.1',
-  '19.1.0', '19.1.1', '19.1.2',
-  '19.2.0', '19.2.1',
+  '19.0.0', '19.0.1', '19.0.2',
+  '19.1.0', '19.1.1', '19.1.2', '19.1.3',
+  '19.2.0', '19.2.1', '19.2.2',
 ];
 
 // React RSC patched versions
 const REACT_RSC_PATCHES = {
-  '19.0.0': '19.0.2',
-  '19.0.1': '19.0.2',
-  '19.1.0': '19.1.3',
-  '19.1.1': '19.1.3',
-  '19.1.2': '19.1.3',
-  '19.2.0': '19.2.2',
-  '19.2.1': '19.2.2',
+  '19.0.0': '19.0.3',
+  '19.0.1': '19.0.3',
+  '19.0.2': '19.0.3',
+  '19.1.0': '19.1.4',
+  '19.1.1': '19.1.4',
+  '19.1.2': '19.1.4',
+  '19.1.3': '19.1.4',
+  '19.2.0': '19.2.3',
+  '19.2.1': '19.2.3',
+  '19.2.2': '19.2.3',
 };
 
 const REACT_RSC_PACKAGES = [

--- a/lib/vulnerabilities/cve-2025-55184.js
+++ b/lib/vulnerabilities/cve-2025-55184.js
@@ -14,7 +14,9 @@
  * - Next.js 15.x canary before 15.6.0-canary.59
  * - Next.js 16.0.x before 16.0.9
  * - Next.js 16.x canary before 16.1.0-canary.18
- * - React RSC packages 19.0.0 through 19.2.1
+ * - react-server-dom-webpack: 19.0.0-19.0.2, 19.1.0-19.1.3, 19.2.0-19.2.2
+ * - react-server-dom-parcel: 19.0.0-19.0.2, 19.1.0-19.1.3, 19.2.0-19.2.2
+ * - react-server-dom-turbopack: 19.0.0-19.0.2, 19.1.0-19.1.3, 19.2.0-19.2.2
  *
  * Note: Next.js Pages Router applications are not affected.
  */
@@ -45,22 +47,25 @@ const NEXT_CANARY_PATCHES = {
   16: '16.1.0-canary.18',
 };
 
-// React RSC vulnerable versions (19.0.0 through 19.2.1)
+// React RSC vulnerable versions (19.0.0 through 19.2.2)
 const REACT_RSC_VULNERABLE_VERSIONS = [
-  '19.0.0', '19.0.1',
-  '19.1.0', '19.1.1', '19.1.2',
-  '19.2.0', '19.2.1',
+  '19.0.0', '19.0.1', '19.0.2',
+  '19.1.0', '19.1.1', '19.1.2', '19.1.3',
+  '19.2.0', '19.2.1', '19.2.2',
 ];
 
 // React RSC patched versions
 const REACT_RSC_PATCHES = {
-  '19.0.0': '19.0.2',
-  '19.0.1': '19.0.2',
-  '19.1.0': '19.1.3',
-  '19.1.1': '19.1.3',
-  '19.1.2': '19.1.3',
-  '19.2.0': '19.2.2',
-  '19.2.1': '19.2.2',
+  '19.0.0': '19.0.3',
+  '19.0.1': '19.0.3',
+  '19.0.2': '19.0.3',
+  '19.1.0': '19.1.4',
+  '19.1.1': '19.1.4',
+  '19.1.2': '19.1.4',
+  '19.1.3': '19.1.4',
+  '19.2.0': '19.2.3',
+  '19.2.1': '19.2.3',
+  '19.2.2': '19.2.3',
 };
 
 const REACT_RSC_PACKAGES = [

--- a/lib/vulnerabilities/cve-2025-66478.js
+++ b/lib/vulnerabilities/cve-2025-66478.js
@@ -3,8 +3,11 @@
  * @see https://vercel.com/kb/bulletin/react2shell
  *
  * Affected packages:
- * - next: 14.3.0-canary.77 through various 15.x/16.x versions
- * - react-server-dom-webpack, react-server-dom-parcel, react-server-dom-turbopack: specific 19.x versions
+ * - next: 14.3.0-canary.77+, all 15.x, all 16.x
+ * - react-server-dom-webpack: 19.0.0, 19.1.0, 19.1.1, 19.2.0
+ * - react-server-dom-parcel: 19.0.0, 19.1.0, 19.1.1, 19.2.0
+ * - react-server-dom-turbopack: 19.0.0, 19.1.0, 19.1.1, 19.2.0
+ * - React core: 19.0.0, 19.1.0, 19.1.1, 19.2.0
  */
 
 const { parseVersion, compareVersions, cleanVersion } = require('../utils/version');

--- a/lib/vulnerabilities/cve-2025-67779.js
+++ b/lib/vulnerabilities/cve-2025-67779.js
@@ -3,7 +3,6 @@
  * @see https://github.com/advisories/GHSA-5j59-xgg2-r9c4
  * @see https://www.cve.org/CVERecord?id=CVE-2025-67779
  *
- *
  * Affected versions:
  * - Next.js 13.x (>= 13.3) - upgrade to 14.2.35
  * - Next.js 14.x before 14.2.35
@@ -16,11 +15,14 @@
  * - Next.js 15.x canary before 15.6.0-canary.60
  * - Next.js 16.0.x before 16.0.10
  * - Next.js 16.x canary before 16.1.0-canary.19
+ * - react-server-dom-webpack: ≤19.0.2, ≤19.1.3, ≤19.2.2
+ * - react-server-dom-parcel: ≤19.0.2, ≤19.1.3, ≤19.2.2
+ * - react-server-dom-turbopack: ≤19.0.2, ≤19.1.3, ≤19.2.2
  *
  * Note: Next.js Pages Router applications are not affected.
  */
 
-const { parseVersion, compareVersions } = require('../utils/version');
+const { parseVersion, compareVersions, cleanVersion } = require('../utils/version');
 
 // Patched versions for Next.js 15.x and 16.x stable releases
 const NEXT_PATCHED_VERSIONS = {
@@ -38,6 +40,33 @@ const NEXT_CANARY_PATCHES = {
   15: '15.6.0-canary.60',
   16: '16.1.0-canary.19',
 };
+
+// React RSC vulnerable versions (≤19.0.2, ≤19.1.3, ≤19.2.2)
+const REACT_RSC_VULNERABLE_VERSIONS = [
+  '19.0.0', '19.0.1', '19.0.2',
+  '19.1.0', '19.1.1', '19.1.2', '19.1.3',
+  '19.2.0', '19.2.1', '19.2.2',
+];
+
+// React RSC patched versions
+const REACT_RSC_PATCHES = {
+  '19.0.0': '19.0.3',
+  '19.0.1': '19.0.3',
+  '19.0.2': '19.0.3',
+  '19.1.0': '19.1.4',
+  '19.1.1': '19.1.4',
+  '19.1.2': '19.1.4',
+  '19.1.3': '19.1.4',
+  '19.2.0': '19.2.3',
+  '19.2.1': '19.2.3',
+  '19.2.2': '19.2.3',
+};
+
+const REACT_RSC_PACKAGES = [
+  'react-server-dom-webpack',
+  'react-server-dom-parcel',
+  'react-server-dom-turbopack',
+];
 
 function isNextVulnerable(version) {
   const parsed = parseVersion(version);
@@ -125,6 +154,16 @@ function isNextVulnerable(version) {
   return { vulnerable: false, reason: 'future-version' };
 }
 
+function isReactRscVulnerable(version) {
+  const cleaned = cleanVersion(version);
+  return REACT_RSC_VULNERABLE_VERSIONS.includes(cleaned);
+}
+
+function getReactRscPatchedVersion(version) {
+  const cleaned = cleanVersion(version);
+  return REACT_RSC_PATCHES[cleaned] || null;
+}
+
 function getNextPatchedVersion(version) {
   const parsed = parseVersion(version);
   if (!parsed) return null;
@@ -180,22 +219,34 @@ function getNextPatchedVersion(version) {
 }
 
 module.exports = {
+  // Metadata
   id: 'CVE-2025-67779',
   name: 'DoS Incomplete Fix Follow-Up',
   severity: 'high',
   description: 'Incomplete fix for CVE-2025-55184 DoS via malicious RSC payload causing infinite loop',
-  packages: ['next'],
 
+  // Packages this CVE applies to
+  packages: ['next', ...REACT_RSC_PACKAGES],
+
+  // Check if a specific package@version is vulnerable
   isVulnerable(packageName, version) {
     if (packageName === 'next') {
       return isNextVulnerable(version);
     }
+    if (REACT_RSC_PACKAGES.includes(packageName)) {
+      return { vulnerable: isReactRscVulnerable(version), reason: 'rsc-version-check' };
+    }
     return { vulnerable: false, reason: 'not-applicable' };
   },
 
+  // Get the minimum version that fixes this CVE
   getPatchedVersion(packageName, version) {
     if (packageName === 'next') {
       return getNextPatchedVersion(version);
+    }
+    if (REACT_RSC_PACKAGES.includes(packageName)) {
+      const patched = getReactRscPatchedVersion(version);
+      return patched ? { recommended: patched } : null;
     }
     return null;
   },

--- a/test/cve-2025-55183.test.js
+++ b/test/cve-2025-55183.test.js
@@ -13,7 +13,7 @@
  * - Next.js 15.x canary before 15.6.0-canary.59
  * - Next.js 16.0.x before 16.0.9
  * - Next.js 16.x canary before 16.1.0-canary.17
- * - React RSC packages 19.0.0 through 19.2.1
+ * - React RSC packages 19.0.0 through 19.2.2
  *
  * Note: Next.js 13.x and 14.x are NOT affected by this CVE (per bulletin table).
  * Note: Pages Router applications are not affected.
@@ -181,15 +181,18 @@ describe('CVE-2025-55183 (Source Code Exposure)', () => {
       'react-server-dom-turbopack',
     ];
 
-    describe('vulnerable React 19 versions (19.0.0 through 19.2.1 per bulletin)', () => {
+    describe('vulnerable React 19 versions (19.0.0 through 19.2.2 per bulletin)', () => {
       const vulnerableVersions = [
         '19.0.0',
         '19.0.1',
+        '19.0.2',
         '19.1.0',
         '19.1.1',
         '19.1.2',
+        '19.1.3',
         '19.2.0',
         '19.2.1',
+        '19.2.2',
       ];
 
       for (const pkg of rscPackages) {
@@ -203,7 +206,7 @@ describe('CVE-2025-55183 (Source Code Exposure)', () => {
     });
 
     describe('patched React RSC versions', () => {
-      const patchedVersions = ['19.0.2', '19.1.3', '19.2.2'];
+      const patchedVersions = ['19.0.3', '19.1.4', '19.2.3'];
 
       for (const pkg of rscPackages) {
         for (const version of patchedVersions) {
@@ -286,19 +289,19 @@ describe('CVE-2025-55183 (Source Code Exposure)', () => {
     });
 
     describe('React RSC patch recommendations', () => {
-      it('should recommend 19.0.2 for 19.0.x', () => {
+      it('should recommend 19.0.3 for 19.0.x', () => {
         const result = cve55183.getPatchedVersion('react-server-dom-webpack', '19.0.0');
-        assert.strictEqual(result.recommended, '19.0.2');
+        assert.strictEqual(result.recommended, '19.0.3');
       });
 
-      it('should recommend 19.1.3 for 19.1.x', () => {
+      it('should recommend 19.1.4 for 19.1.x', () => {
         const result = cve55183.getPatchedVersion('react-server-dom-webpack', '19.1.0');
-        assert.strictEqual(result.recommended, '19.1.3');
+        assert.strictEqual(result.recommended, '19.1.4');
       });
 
-      it('should recommend 19.2.2 for 19.2.x', () => {
+      it('should recommend 19.2.3 for 19.2.x', () => {
         const result = cve55183.getPatchedVersion('react-server-dom-webpack', '19.2.0');
-        assert.strictEqual(result.recommended, '19.2.2');
+        assert.strictEqual(result.recommended, '19.2.3');
       });
     });
   });

--- a/test/cve-2025-55184.test.js
+++ b/test/cve-2025-55184.test.js
@@ -1,7 +1,7 @@
 /**
  * Tests for CVE-2025-55184 (Denial of Service) vulnerability detection
  *
- * These vulnerabilities affect React versions 19.0.0 through 19.2.1
+ * These vulnerabilities affect React versions 19.0.0 through 19.2.2
  * and Next.js versions 13.x through 16.x.
  *
  * Affected versions (DoS):
@@ -242,15 +242,18 @@ describe('CVE-2025-55184 (Denial of Service)', () => {
       'react-server-dom-turbopack',
     ];
 
-    describe('vulnerable React 19 versions (19.0.0 through 19.2.1 per bulletin)', () => {
+    describe('vulnerable React 19 versions (19.0.0 through 19.2.2 per bulletin)', () => {
       const vulnerableVersions = [
         '19.0.0',
         '19.0.1',
+        '19.0.2',
         '19.1.0',
         '19.1.1',
         '19.1.2',
+        '19.1.3',
         '19.2.0',
         '19.2.1',
+        '19.2.2',
       ];
 
       for (const pkg of rscPackages) {
@@ -264,7 +267,7 @@ describe('CVE-2025-55184 (Denial of Service)', () => {
     });
 
     describe('patched React RSC versions', () => {
-      const patchedVersions = ['19.0.2', '19.1.3', '19.2.2'];
+      const patchedVersions = ['19.0.3', '19.1.4', '19.2.3'];
 
       for (const pkg of rscPackages) {
         for (const version of patchedVersions) {
@@ -347,19 +350,19 @@ describe('CVE-2025-55184 (Denial of Service)', () => {
     });
 
     describe('React RSC patch recommendations', () => {
-      it('should recommend 19.0.2 for 19.0.x', () => {
+      it('should recommend 19.0.3 for 19.0.x', () => {
         const result = cve55184.getPatchedVersion('react-server-dom-webpack', '19.0.0');
-        assert.strictEqual(result.recommended, '19.0.2');
+        assert.strictEqual(result.recommended, '19.0.3');
       });
 
-      it('should recommend 19.1.3 for 19.1.x', () => {
+      it('should recommend 19.1.4 for 19.1.x', () => {
         const result = cve55184.getPatchedVersion('react-server-dom-webpack', '19.1.0');
-        assert.strictEqual(result.recommended, '19.1.3');
+        assert.strictEqual(result.recommended, '19.1.4');
       });
 
-      it('should recommend 19.2.2 for 19.2.x', () => {
+      it('should recommend 19.2.3 for 19.2.x', () => {
         const result = cve55184.getPatchedVersion('react-server-dom-webpack', '19.2.0');
-        assert.strictEqual(result.recommended, '19.2.2');
+        assert.strictEqual(result.recommended, '19.2.3');
       });
     });
   });

--- a/test/cve-2025-67779.test.js
+++ b/test/cve-2025-67779.test.js
@@ -1,0 +1,376 @@
+/**
+ * Tests for CVE-2025-67779 (DoS Incomplete Fix Follow-Up) vulnerability detection
+ *
+ * This CVE affects Next.js and React Server Components packages.
+ * It was discovered that the fixes for CVE-2025-55184 were incomplete.
+ *
+ * Affected versions (DoS Incomplete Fix):
+ * - Next.js 13.x (>= 13.3) - upgrade to 14.2.35
+ * - Next.js 14.x before 14.2.35
+ * - Next.js 15.0.x before 15.0.7
+ * - Next.js 15.1.x before 15.1.11
+ * - Next.js 15.2.x before 15.2.8
+ * - Next.js 15.3.x before 15.3.8
+ * - Next.js 15.4.x before 15.4.10
+ * - Next.js 15.5.x before 15.5.9
+ * - Next.js 15.x canary before 15.6.0-canary.60
+ * - Next.js 16.0.x before 16.0.10
+ * - Next.js 16.x canary before 16.1.0-canary.19
+ * - react-server-dom-webpack: ≤19.0.2, ≤19.1.3, ≤19.2.2
+ * - react-server-dom-parcel: ≤19.0.2, ≤19.1.3, ≤19.2.2
+ * - react-server-dom-turbopack: ≤19.0.2, ≤19.1.3, ≤19.2.2
+ *
+ * Note: Next.js Pages Router applications are not affected.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const cve67779 = require('../lib/vulnerabilities/cve-2025-67779');
+
+describe('CVE-2025-67779 (DoS Incomplete Fix Follow-Up)', () => {
+  describe('Next.js vulnerability detection', () => {
+    describe('versions NOT affected (before App Router - 13.3)', () => {
+      const safeVersions = [
+        '12.0.0',
+        '12.3.4',
+        '13.0.0',
+        '13.1.0',
+        '13.2.0',
+        '13.2.9', // last version before App Router
+      ];
+
+      for (const version of safeVersions) {
+        it(`should NOT flag ${version} as vulnerable (before App Router)`, () => {
+          const result = cve67779.isVulnerable('next', version);
+          assert.strictEqual(result.vulnerable, false, `Expected ${version} to NOT be vulnerable`);
+        });
+      }
+    });
+
+    describe('Next.js 13.x (>= 13.3) - vulnerable, must upgrade to 14.2.35', () => {
+      const vulnerableVersions = [
+        '13.3.0',  // App Router introduced
+        '13.4.0',
+        '13.5.0',
+        '13.5.6',
+      ];
+
+      for (const version of vulnerableVersions) {
+        it(`should flag ${version} as vulnerable`, () => {
+          const result = cve67779.isVulnerable('next', version);
+          assert.strictEqual(result.vulnerable, true, `Expected ${version} to be vulnerable`);
+        });
+
+        it(`should recommend 14.2.35 for ${version}`, () => {
+          const result = cve67779.getPatchedVersion('next', version);
+          assert.strictEqual(result.recommended, '14.2.35');
+        });
+      }
+    });
+
+    describe('Next.js 14.x - vulnerable before 14.2.35', () => {
+      const vulnerableVersions = [
+        '14.0.0',
+        '14.1.0',
+        '14.2.0',
+        '14.2.34',
+      ];
+
+      for (const version of vulnerableVersions) {
+        it(`should flag ${version} as vulnerable`, () => {
+          const result = cve67779.isVulnerable('next', version);
+          assert.strictEqual(result.vulnerable, true, `Expected ${version} to be vulnerable`);
+        });
+      }
+
+      it('should NOT flag 14.2.35 as vulnerable (patched)', () => {
+        const result = cve67779.isVulnerable('next', '14.2.35');
+        assert.strictEqual(result.vulnerable, false);
+      });
+
+      it('should NOT flag 14.2.36 as vulnerable', () => {
+        const result = cve67779.isVulnerable('next', '14.2.36');
+        assert.strictEqual(result.vulnerable, false);
+      });
+    });
+
+    describe('Next.js 14.x canaries - all vulnerable (no patch available per bulletin)', () => {
+      const vulnerableCanaries = [
+        '14.3.0-canary.0',
+        '14.3.0-canary.76',
+        '14.3.0-canary.77',
+        '14.3.0-canary.100',
+      ];
+
+      for (const version of vulnerableCanaries) {
+        it(`should flag ${version} as vulnerable`, () => {
+          const result = cve67779.isVulnerable('next', version);
+          assert.strictEqual(result.vulnerable, true, `Expected ${version} to be vulnerable`);
+        });
+      }
+    });
+
+    describe('Next.js 15.x - vulnerable versions', () => {
+      const vulnerableVersions = [
+        '15.0.0',
+        '15.0.6',  // previous patch for DoS, not enough for this follow-up
+        '15.1.0',
+        '15.1.10',  // previous patch for DoS, not enough for this follow-up
+        '15.2.0',
+        '15.2.7',  // previous patch for DoS, not enough for this follow-up
+        '15.3.0',
+        '15.3.7',  // previous patch for DoS, not enough for this follow-up
+        '15.4.0',
+        '15.4.9',  // previous patch for DoS, not enough for this follow-up
+        '15.5.0',
+        '15.5.8',  // previous patch for DoS, not enough for this follow-up
+      ];
+
+      for (const version of vulnerableVersions) {
+        it(`should flag ${version} as vulnerable`, () => {
+          const result = cve67779.isVulnerable('next', version);
+          assert.strictEqual(result.vulnerable, true, `Expected ${version} to be vulnerable`);
+        });
+      }
+    });
+
+    describe('Next.js 15.x - patched versions (per new bulletin)', () => {
+      const patchedVersions = [
+        '15.0.7',
+        '15.1.11',
+        '15.2.8',
+        '15.3.8',
+        '15.4.10',
+        '15.5.9',
+      ];
+
+      for (const version of patchedVersions) {
+        it(`should NOT flag ${version} as vulnerable (patched)`, () => {
+          const result = cve67779.isVulnerable('next', version);
+          assert.strictEqual(result.vulnerable, false, `Expected ${version} to NOT be vulnerable`);
+        });
+      }
+    });
+
+    describe('Next.js 15.x canaries', () => {
+      it('should flag 15.6.0-canary.59 as vulnerable (patch is .60)', () => {
+        const result = cve67779.isVulnerable('next', '15.6.0-canary.59');
+        assert.strictEqual(result.vulnerable, true);
+      });
+
+      it('should NOT flag 15.6.0-canary.60 as vulnerable (patched)', () => {
+        const result = cve67779.isVulnerable('next', '15.6.0-canary.60');
+        assert.strictEqual(result.vulnerable, false);
+      });
+
+      it('should NOT flag 15.6.0-canary.61 as vulnerable', () => {
+        const result = cve67779.isVulnerable('next', '15.6.0-canary.61');
+        assert.strictEqual(result.vulnerable, false);
+      });
+    });
+
+    describe('Next.js 16.x - vulnerable versions', () => {
+      const vulnerableVersions = [
+        '16.0.0',
+        '16.0.9',  // previous patch for DoS, not enough for this follow-up
+      ];
+
+      for (const version of vulnerableVersions) {
+        it(`should flag ${version} as vulnerable`, () => {
+          const result = cve67779.isVulnerable('next', version);
+          assert.strictEqual(result.vulnerable, true, `Expected ${version} to be vulnerable`);
+        });
+      }
+    });
+
+    describe('Next.js 16.x - patched versions', () => {
+      it('should NOT flag 16.0.10 as vulnerable (patched)', () => {
+        const result = cve67779.isVulnerable('next', '16.0.10');
+        assert.strictEqual(result.vulnerable, false);
+      });
+
+      it('should NOT flag 16.0.11 as vulnerable', () => {
+        const result = cve67779.isVulnerable('next', '16.0.11');
+        assert.strictEqual(result.vulnerable, false);
+      });
+
+      it('should NOT flag 16.1.0 as vulnerable', () => {
+        const result = cve67779.isVulnerable('next', '16.1.0');
+        assert.strictEqual(result.vulnerable, false);
+      });
+    });
+
+    describe('Next.js 16.x canaries', () => {
+      it('should flag 16.1.0-canary.18 as vulnerable (patch is .19)', () => {
+        const result = cve67779.isVulnerable('next', '16.1.0-canary.18');
+        assert.strictEqual(result.vulnerable, true);
+      });
+
+      it('should NOT flag 16.1.0-canary.19 as vulnerable (patched)', () => {
+        const result = cve67779.isVulnerable('next', '16.1.0-canary.19');
+        assert.strictEqual(result.vulnerable, false);
+      });
+
+      it('should NOT flag 16.1.0-canary.20 as vulnerable', () => {
+        const result = cve67779.isVulnerable('next', '16.1.0-canary.20');
+        assert.strictEqual(result.vulnerable, false);
+      });
+    });
+
+    describe('Future versions (17+) - assume safe', () => {
+      it('should NOT flag 17.0.0 as vulnerable', () => {
+        const result = cve67779.isVulnerable('next', '17.0.0');
+        assert.strictEqual(result.vulnerable, false);
+      });
+    });
+  });
+
+  describe('React RSC package vulnerability detection', () => {
+    const rscPackages = [
+      'react-server-dom-webpack',
+      'react-server-dom-parcel',
+      'react-server-dom-turbopack',
+    ];
+
+    describe('vulnerable React 19 versions (≤19.0.2, ≤19.1.3, ≤19.2.2 per bulletin)', () => {
+      const vulnerableVersions = [
+        '19.0.0',
+        '19.0.1',
+        '19.0.2',
+        '19.1.0',
+        '19.1.1',
+        '19.1.2',
+        '19.1.3',
+        '19.2.0',
+        '19.2.1',
+        '19.2.2',
+      ];
+
+      for (const pkg of rscPackages) {
+        for (const version of vulnerableVersions) {
+          it(`should flag ${pkg}@${version} as vulnerable`, () => {
+            const result = cve67779.isVulnerable(pkg, version);
+            assert.strictEqual(result.vulnerable, true, `Expected ${pkg}@${version} to be vulnerable`);
+          });
+        }
+      }
+    });
+
+    describe('patched React RSC versions', () => {
+      const patchedVersions = ['19.0.3', '19.1.4', '19.2.3'];
+
+      for (const pkg of rscPackages) {
+        for (const version of patchedVersions) {
+          it(`should NOT flag ${pkg}@${version} as vulnerable`, () => {
+            const result = cve67779.isVulnerable(pkg, version);
+            assert.strictEqual(result.vulnerable, false, `Expected ${pkg}@${version} to NOT be vulnerable`);
+          });
+        }
+      }
+    });
+
+    describe('React versions before 19 are not affected', () => {
+      const safeVersions = ['18.0.0', '18.2.0', '18.3.1'];
+
+      for (const pkg of rscPackages) {
+        for (const version of safeVersions) {
+          it(`should NOT flag ${pkg}@${version} as vulnerable`, () => {
+            const result = cve67779.isVulnerable(pkg, version);
+            assert.strictEqual(result.vulnerable, false, `Expected ${pkg}@${version} to NOT be vulnerable`);
+          });
+        }
+      }
+    });
+  });
+
+  describe('getPatchedVersion recommendations', () => {
+    it('should recommend 14.2.35 for 13.x (>= 13.3)', () => {
+      const result = cve67779.getPatchedVersion('next', '13.4.0');
+      assert.strictEqual(result.recommended, '14.2.35');
+    });
+
+    it('should recommend 14.2.35 for 14.x stable', () => {
+      const result = cve67779.getPatchedVersion('next', '14.1.0');
+      assert.strictEqual(result.recommended, '14.2.35');
+    });
+
+    it('should recommend 15.0.7 for 15.0.x', () => {
+      const result = cve67779.getPatchedVersion('next', '15.0.0');
+      assert.strictEqual(result.recommended, '15.0.7');
+    });
+
+    it('should recommend 15.1.11 for 15.1.x', () => {
+      const result = cve67779.getPatchedVersion('next', '15.1.0');
+      assert.strictEqual(result.recommended, '15.1.11');
+    });
+
+    it('should recommend 15.2.8 for 15.2.x', () => {
+      const result = cve67779.getPatchedVersion('next', '15.2.0');
+      assert.strictEqual(result.recommended, '15.2.8');
+    });
+
+    it('should recommend 15.3.8 for 15.3.x', () => {
+      const result = cve67779.getPatchedVersion('next', '15.3.0');
+      assert.strictEqual(result.recommended, '15.3.8');
+    });
+
+    it('should recommend 15.4.10 for 15.4.x', () => {
+      const result = cve67779.getPatchedVersion('next', '15.4.0');
+      assert.strictEqual(result.recommended, '15.4.10');
+    });
+
+    it('should recommend 15.5.9 for 15.5.x', () => {
+      const result = cve67779.getPatchedVersion('next', '15.5.0');
+      assert.strictEqual(result.recommended, '15.5.9');
+    });
+
+    it('should recommend 16.0.10 for 16.0.x', () => {
+      const result = cve67779.getPatchedVersion('next', '16.0.0');
+      assert.strictEqual(result.recommended, '16.0.10');
+    });
+
+    it('should recommend 15.6.0-canary.60 for 15.x canaries', () => {
+      const result = cve67779.getPatchedVersion('next', '15.6.0-canary.0');
+      assert.strictEqual(result.recommended, '15.6.0-canary.60');
+    });
+
+    it('should recommend 16.1.0-canary.19 for 16.x canaries', () => {
+      const result = cve67779.getPatchedVersion('next', '16.1.0-canary.0');
+      assert.strictEqual(result.recommended, '16.1.0-canary.19');
+    });
+
+    describe('React RSC patch recommendations', () => {
+      it('should recommend 19.0.3 for 19.0.x', () => {
+        const result = cve67779.getPatchedVersion('react-server-dom-webpack', '19.0.0');
+        assert.strictEqual(result.recommended, '19.0.3');
+      });
+
+      it('should recommend 19.1.4 for 19.1.x', () => {
+        const result = cve67779.getPatchedVersion('react-server-dom-webpack', '19.1.0');
+        assert.strictEqual(result.recommended, '19.1.4');
+      });
+
+      it('should recommend 19.2.3 for 19.2.x', () => {
+        const result = cve67779.getPatchedVersion('react-server-dom-webpack', '19.2.0');
+        assert.strictEqual(result.recommended, '19.2.3');
+      });
+    });
+  });
+
+  describe('metadata', () => {
+    it('should have correct CVE ID', () => {
+      assert.strictEqual(cve67779.id, 'CVE-2025-67779');
+    });
+
+    it('should have high severity', () => {
+      assert.strictEqual(cve67779.severity, 'high');
+    });
+
+    it('should include all relevant packages', () => {
+      assert.ok(cve67779.packages.includes('next'));
+      assert.ok(cve67779.packages.includes('react-server-dom-webpack'));
+      assert.ok(cve67779.packages.includes('react-server-dom-parcel'));
+      assert.ok(cve67779.packages.includes('react-server-dom-turbopack'));
+    });
+  });
+});

--- a/test/minimal-fixes.test.js
+++ b/test/minimal-fixes.test.js
@@ -338,11 +338,11 @@ describe('computeMinimalFixes', () => {
   });
 
   describe('handles React RSC packages', () => {
-    it('should select 19.0.2 for react-server-dom-webpack@19.0.0', () => {
+    it('should select 19.0.3 for react-server-dom-webpack@19.0.0', () => {
       // React RSC 19.0.x patch versions for DoS and Source Code Exposure:
       // - CVE-2025-66478: 19.0.1
-      // - CVE-2025-55184: 19.0.2
-      // - CVE-2025-55183: 19.0.2
+      // - CVE-2025-55184: 19.0.3
+      // - CVE-2025-55183: 19.0.3
 
       const analysisResults = [{
         path: '/test/package.json',
@@ -352,8 +352,8 @@ describe('computeMinimalFixes', () => {
           current: '19.0.0',
           cves: [
             { id: 'CVE-2025-66478', severity: 'critical', patchedVersion: '19.0.1' },
-            { id: 'CVE-2025-55184', severity: 'high', patchedVersion: '19.0.2' },
-            { id: 'CVE-2025-55183', severity: 'medium', patchedVersion: '19.0.2' },
+            { id: 'CVE-2025-55184', severity: 'high', patchedVersion: '19.0.3' },
+            { id: 'CVE-2025-55183', severity: 'medium', patchedVersion: '19.0.3' },
           ],
           inDeps: true,
           inDevDeps: false,
@@ -361,14 +361,14 @@ describe('computeMinimalFixes', () => {
       }];
 
       const fixes = computeMinimalFixes(analysisResults);
-      assert.strictEqual(fixes[0].fixes[0].patched, '19.0.2');
+      assert.strictEqual(fixes[0].fixes[0].patched, '19.0.3');
     });
 
-    it('should select 19.1.3 for react-server-dom-webpack@19.1.0', () => {
+    it('should select 19.1.4 for react-server-dom-webpack@19.1.0', () => {
       // React RSC 19.1.x patch versions:
       // - CVE-2025-66478: 19.1.2
-      // - CVE-2025-55184: 19.1.3
-      // - CVE-2025-55183: 19.1.3
+      // - CVE-2025-55184: 19.1.4
+      // - CVE-2025-55183: 19.1.4
 
       const analysisResults = [{
         path: '/test/package.json',
@@ -378,8 +378,8 @@ describe('computeMinimalFixes', () => {
           current: '19.1.0',
           cves: [
             { id: 'CVE-2025-66478', severity: 'critical', patchedVersion: '19.1.2' },
-            { id: 'CVE-2025-55184', severity: 'high', patchedVersion: '19.1.3' },
-            { id: 'CVE-2025-55183', severity: 'medium', patchedVersion: '19.1.3' },
+            { id: 'CVE-2025-55184', severity: 'high', patchedVersion: '19.1.4' },
+            { id: 'CVE-2025-55183', severity: 'medium', patchedVersion: '19.1.4' },
           ],
           inDeps: true,
           inDevDeps: false,
@@ -387,14 +387,14 @@ describe('computeMinimalFixes', () => {
       }];
 
       const fixes = computeMinimalFixes(analysisResults);
-      assert.strictEqual(fixes[0].fixes[0].patched, '19.1.3');
+      assert.strictEqual(fixes[0].fixes[0].patched, '19.1.4');
     });
 
-    it('should select 19.2.2 for react-server-dom-webpack@19.2.0', () => {
+    it('should select 19.2.3 for react-server-dom-webpack@19.2.0', () => {
       // React RSC 19.2.x patch versions:
       // - CVE-2025-66478: 19.2.1
-      // - CVE-2025-55184: 19.2.2
-      // - CVE-2025-55183: 19.2.2
+      // - CVE-2025-55184: 19.2.3
+      // - CVE-2025-55183: 19.2.3
 
       const analysisResults = [{
         path: '/test/package.json',
@@ -404,8 +404,8 @@ describe('computeMinimalFixes', () => {
           current: '19.2.0',
           cves: [
             { id: 'CVE-2025-66478', severity: 'critical', patchedVersion: '19.2.1' },
-            { id: 'CVE-2025-55184', severity: 'high', patchedVersion: '19.2.2' },
-            { id: 'CVE-2025-55183', severity: 'medium', patchedVersion: '19.2.2' },
+            { id: 'CVE-2025-55184', severity: 'high', patchedVersion: '19.2.3' },
+            { id: 'CVE-2025-55183', severity: 'medium', patchedVersion: '19.2.3' },
           ],
           inDeps: true,
           inDevDeps: false,
@@ -413,7 +413,7 @@ describe('computeMinimalFixes', () => {
       }];
 
       const fixes = computeMinimalFixes(analysisResults);
-      assert.strictEqual(fixes[0].fixes[0].patched, '19.2.2');
+      assert.strictEqual(fixes[0].fixes[0].patched, '19.2.3');
     });
   });
 
@@ -440,8 +440,9 @@ describe('computeMinimalFixes', () => {
             current: '19.1.0',
             cves: [
               { id: 'CVE-2025-66478', severity: 'critical', patchedVersion: '19.1.2' },
-              { id: 'CVE-2025-55184', severity: 'high', patchedVersion: '19.1.3' },
-              { id: 'CVE-2025-55183', severity: 'medium', patchedVersion: '19.1.3' },
+              { id: 'CVE-2025-55184', severity: 'high', patchedVersion: '19.1.4' },
+              { id: 'CVE-2025-55183', severity: 'medium', patchedVersion: '19.1.4' },
+              { id: 'CVE-2025-67779', severity: 'high', patchedVersion: '19.1.4' },
             ],
             inDeps: true,
             inDevDeps: false,
@@ -458,7 +459,7 @@ describe('computeMinimalFixes', () => {
       const rscFix = fixes[0].fixes.find(f => f.package === 'react-server-dom-webpack');
 
       assert.strictEqual(nextFix.patched, '15.3.8');
-      assert.strictEqual(rscFix.patched, '19.1.3');
+      assert.strictEqual(rscFix.patched, '19.1.4');
     });
   });
 


### PR DESCRIPTION


The current fix-react2shell-next tool only fixes CVE-2025-66478 but claims to address React2Shell vulnerabilities. Users running this tool remain exposed to CVE-2025-55184, CVE-2025-55183, and CVE-2025-67779.

Changes Made
- Updated CVE-2025-55184 and CVE-2025-55183 to require React versions 19.0.3+, 19.1.4+, 19.2.3+ (previously only went to 19.2.2 and marks as "safe" when it is actually still vulnerable to multiple CVEs.)
- Added React Server Components package support to CVE-2025-67779
- Updated all documentation and test files to reflect complete coverage

---

Before our fix:
CVE-2025-55184: Marked React 19.2.2 as ✅ "safe" (fixed)
CVE-2025-55183: Marked React 19.2.2 as ✅ "safe" (fixed)
CVE-2025-67779: Marked React 19.2.2 as ✅ "safe" (fixed)
Reality: React 19.2.2 was still vulnerable to CVE-2025-67779 (DoS attacks), meaning the previous "fixes" for CVE-2025-55184 were incomplete.

After our fix:
CVE-2025-55184: Now correctly marks React 19.2.2 as ❌ "vulnerable"
CVE-2025-55183: Now correctly marks React 19.2.2 as ❌ "vulnerable"
CVE-2025-67779: Now properly detects React 19.2.2 as ❌ "vulnerable"
Only React 19.2.3+ is marked as ✅ truly "safe" from all CVEs